### PR TITLE
Update QDateTime function call for Qt 6

### DIFF
--- a/Reset_review_Stats_in_Anki.py
+++ b/Reset_review_Stats_in_Anki.py
@@ -130,7 +130,7 @@ def custom_reset(deck, from_date, to_date):
         deck2 = "and cid in (select id from cards where did = {})".format(deck.currentData())
     reset = askUser("Are you sure you want to delete review history for all cards in \"{}\" reviewed from \"{}\" to \"{}\"? \n This can't be undone.".format(deck.currentText(), from_date.toString("MM/dd/yyyy"), to_date.toString("MM/dd/yyyy")))
     if reset:
-        mw.col.db.execute("delete from revlog where {} > id and id > {} {}".format(to_date.toTime_t() * 1000, from_date.toTime_t() * 1000, deck2))
+        mw.col.db.execute("delete from revlog where {} > id and id > {} {}".format(to_date.toSecsSinceEpoch() * 1000, from_date.toSecsSinceEpoch() * 1000, deck2))
         showInfo("Done")
     else:
         return


### PR DESCRIPTION
toTime_t() is obsolete and has been deprecated. toSecsSinceEpoch() returns the same value but as a qint64 instead of a uint.

Tested working as expected in Anki 2.1.65 (aa9a734f) Python 3.9.15 Qt 6.4.3 PyQt 6.4.0

This patch addresses only this issue. Other issues remain.