### PR TITLE
Updated custom reset dialog enums for Qt6

### DIFF
--- a/Reset_review_Stats_in_Anki.py
+++ b/Reset_review_Stats_in_Anki.py
@@ -101,13 +101,13 @@ def time_window():
         did_list.append(deck_id)
     from_label = QLabel("Reviewed from")
     from_date = QDateTimeEdit()
-    from_date.setAlignment(Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
+    from_date.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
     from_date.setMinimumDate(QDate(2006, 10, 5))
     from_date.setDate(QDate.currentDate().addDays(-10))
     from_date.setCalendarPopup(True)
     to_label = QLabel("to")
     to_date = QDateTimeEdit()
-    to_date.setAlignment(Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
+    to_date.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
     to_date.setMinimumDate(QDate(2006, 10, 5))
     to_date.setDate(QDate.currentDate())
     to_date.setCalendarPopup(True)
@@ -121,7 +121,7 @@ def time_window():
     layout.addWidget(to_label)
     layout.addWidget(to_date)
     window.setLayout(layout)
-    window.exec_()
+    window.exec()
 
 def custom_reset(deck, from_date, to_date):
     if deck.currentData() == "collection":


### PR DESCRIPTION
Some of the enums used for alignment (such as `Qt.AlignRight`) have been replaced with longer forms in Qt6 (e.g. `Qt.AlignmentFlag.AlignRight`). This caused the issue that was recently reported on AnkiWeb. (the one stating `AttributeError: type object 'Qt' has no attribute 'AlignRight'`). Additionally, the `exec_()` method of `QDialog` has been replaced with `exec()` in Qt6 (see [here](https://www.riverbankcomputing.com/static/Docs/PyQt6/pyqt5_differences.html)). This PR changes the enums for the custom reset dialog and `exec` methods to their Qt6 versions.

Note that this has only recently started to cause errors as Anki disabled Qt5 compatibility by default in October 2023 (as stated [here](https://forums.ankiweb.net/t/porting-tips-for-anki-23-10/35916)).

P.S. It would be nice if you added the GitHub link to the AnkiWeb add-on page.